### PR TITLE
save trk as compressed

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -3019,7 +3019,7 @@ class TrackReview(CalibanWindow):
         	del self.tracks[track]
 
         try:
-            with tarfile.open(self.filename + ".trk", "w") as trks:
+            with tarfile.open(self.filename + ".trk", "w:gz") as trks:
                 with tempfile.NamedTemporaryFile("w") as lineage_file:
                     json.dump(self.tracks, lineage_file, indent=1)
                     lineage_file.flush()
@@ -4931,7 +4931,7 @@ class ZStackReview(CalibanWindow):
         trk_ann[:,:,:,0] = self.annotated[:,:,:,self.feature]
 
         try:
-            with tarfile.open(filename + ".trk", "w") as trks:
+            with tarfile.open(filename + ".trk", "w:gz") as trks:
                 with tempfile.NamedTemporaryFile("w") as lineage_file:
                     json.dump(self.lineage, lineage_file, indent=1)
                     lineage_file.flush()


### PR DESCRIPTION
## What
Save .trk files as compressed archives

## Why
This saves ~40% of file size at the cost of ~2x the computation time used for compression. Since we will have a lot of these files, saving space would be a benefit
