### PR TITLE
annotation displays with random color map

### DIFF
--- a/desktop/caliban.py
+++ b/desktop/caliban.py
@@ -184,7 +184,9 @@ class CalibanWindow:
         self.hide_annotations = False
 
         # set cmap for labels here (easier to set_bad just once)
-        self.labels_cmap = plt.get_cmap("viridis")
+        vals = np.linspace(0,1,256)
+        np.random.shuffle(vals)
+        self.labels_cmap = plt.cm.colors.ListedColormap(plt.cm.viridis(vals))
         self.labels_cmap.set_bad('black')
 
         # composite_view used to store RGB image (composite of raw and annotated) so it can be


### PR DESCRIPTION
## What
- Use random colormap instead of standard viridis. Closes #1.

## Why
- As described in #1, having similar colors for adjacent cells makes it difficult to scan a frame and spot errors. Randomizing the colormap goes a long way to improve this. There will still be some adjacent cells with similar colors but now this happens a few times a frame instead of always.

| Before | After |
|- |-	|
| ![Screen Shot 2020-10-15 at 6 31 23 PM](https://user-images.githubusercontent.com/19571703/96202769-eb842280-0f14-11eb-95d5-bd8200abffdf.png) | ![Screen Shot 2020-10-15 at 6 17 01 PM](https://user-images.githubusercontent.com/19571703/96202787-f6d74e00-0f14-11eb-8a6c-dfe3cbf0bfad.png) |