### PR TITLE
Allow VNC to be shared

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -79,7 +79,7 @@ run_vnc_server() {
         log_w "The VNC server will NOT ask for a password"
     fi
 
-    x11vnc -display ${DISPLAY} -forever ${passwordArgument} &
+    x11vnc -display ${DISPLAY} -shared -forever ${passwordArgument} &
     wait $!
 }
 


### PR DESCRIPTION
## What
Edit settings when container starts to allow VNC to be shared.

## Why
This allows multiple users to access one VNC server for sharing of info.
